### PR TITLE
fix HTTP kernel error

### DIFF
--- a/packages/deepkit-openapi/src/module.ts
+++ b/packages/deepkit-openapi/src/module.ts
@@ -146,6 +146,7 @@ export class OpenAPIModule extends createModule({
 
         event.routeFound(
           new RouteConfig("static", ["GET"], event.url, {
+            type: 'controller',
             controller: OpenApiStaticRewritingListener,
             module,
             methodName: "serve",


### PR DESCRIPTION
As of [deepkit-framework v1.0.1-alpha.72](https://github.com/deepkit/deepkit-framework/commit/30939492b96fd90d027728fc7a3030e8d8d24bf3), the `type` property is expected in `RouteConfig`'s `action`.  Without it, the following error occurs:

```
2022-07-21T05:03:52.290Z [ERROR] HTTP kernel request failed TypeError: Cannot read properties of undefined (reading 'name')
    at HttpListener.onController (/Users/sean/Code/sample/node_modules/@deepkit/http/src/http.ts:643:37)
    at self (eval at buildAsync (/Users/sean/Code/sample/node_modules/@deepkit/core/src/compiler.ts:111:20), <anonymous>:186:51)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at HttpKernel.handleRequest (/Users/sean/Code/sample/node_modules/@deepkit/http/src/kernel.ts:40:17)
```