### PR TITLE
redirect to index.html on directory access

### DIFF
--- a/packages/deepkit-openapi/src/module.ts
+++ b/packages/deepkit-openapi/src/module.ts
@@ -117,6 +117,11 @@ export class OpenAPIModule extends createModule({
               "/",
               request.url!.substring(this.prefix.length),
             );
+            if (relativePath === "") {
+              response.setHeader("location", this.prefix + "index.html");
+              response.status(301);
+              return;
+            }
             const finalLocalPath = join(this.staticDirectory, relativePath);
 
             const statResult = await stat(finalLocalPath);


### PR DESCRIPTION
This would enable users to type in `http://localhost:3000/openapi/`, without having to explicitly enter `index.html`.