### PR TITLE
resolve validator undefined error

### DIFF
--- a/packages/deepkit-openapi-core/src/TypeSchemaResolver.ts
+++ b/packages/deepkit-openapi-core/src/TypeSchemaResolver.ts
@@ -242,15 +242,15 @@ export class TypeSchemaResolver {
         this.errors.push(
           new TypeNotSupported(this.t, `Validator ${name} is not supported. `),
         );
-      }
-
-      try {
-        this.result = validator(this.result, ...(args as [any]));
-      } catch (e) {
-        if (e instanceof TypeNotSupported) {
-          this.errors.push(e);
-        } else {
-          throw e;
+      } else {
+        try {
+          this.result = validator(this.result, ...(args as [any]));
+        } catch (e) {
+          if (e instanceof TypeNotSupported) {
+            this.errors.push(e);
+          } else {
+            throw e;
+          }
         }
       }
     }


### PR DESCRIPTION
Currently, if the validator is not supported by the validators object, an error is pushed onto the errors array, but then the non-existent validator is immediately invoked.  The net result:

```
2023-03-18T22:33:25.921Z [ERROR] Controller error TypeError: validator is not a function
    at TypeSchemaResolver.resolveValidators (/Users/sean/Desktop/test-app/node_modules/deepkit-openapi-core/dist/cjs/src/TypeSchemaResolver.js:190:35)
    at TypeSchemaResolver.resolve (/Users/sean/Desktop/test-app/node_modules/deepkit-openapi-core/dist/cjs/src/TypeSchemaResolver.js:205:14)
    at /Users/sean/Desktop/test-app/node_modules/deepkit-openapi-core/dist/cjs/src/TypeSchemaResolver.js:238:41
    at TypeSchemaResolver.resolveClassOrObjectLiteral (/Users/sean/Desktop/test-app/node_modules/deepkit-openapi-core/dist/cjs/src/TypeSchemaResolver.js:116:72)
    at TypeSchemaResolver.resolveBasic (/Users/sean/Desktop/test-app/node_modules/deepkit-openapi-core/dist/cjs/src/TypeSchemaResolver.js:69:22)
    at TypeSchemaResolver.resolve (/Users/sean/Desktop/test-app/node_modules/deepkit-openapi-core/dist/cjs/src/TypeSchemaResolver.js:204:14)
    at /Users/sean/Desktop/test-app/node_modules/deepkit-openapi-core/dist/cjs/src/TypeSchemaResolver.js:238:41
    at ParametersResolver.resolve (/Users/sean/Desktop/test-app/node_modules/deepkit-openapi-core/dist/cjs/src/ParametersResolver.js:72:79)
    at OpenAPIDocument.registerRoute (/Users/sean/Desktop/test-app/node_modules/deepkit-openapi-core/dist/cjs/src/OpenAPIDocument.js:110:118)
    at OpenAPIDocument.getDocument (/Users/sean/Desktop/test-app/node_modules/deepkit-openapi-core/dist/cjs/src/OpenAPIDocument.js:56:18)
```