### PR TITLE
add / between base and route

### DIFF
--- a/packages/deepkit-openapi-core/src/OpenAPIDocument.ts
+++ b/packages/deepkit-openapi-core/src/OpenAPIDocument.ts
@@ -137,9 +137,11 @@ export class OpenAPIDocument {
       if (route.action.type !== 'controller') {
         throw new Error('Sorry, only controller routes are currently supported!');
       }
+      
+      const slash = route.path.length === 0 || route.path.startsWith('/') ? '' : '/';
 
       const operation: Operation = {
-        __path: `${route.baseUrl}${route.path}`,
+        __path: `${route.baseUrl}${slash}${route.path}`,
         __method: method.toLowerCase(),
         tags: [tag.name],
         operationId: camelcase([method, tag.name, route.action.methodName]),


### PR DESCRIPTION
Deepkit allows for the following:
```
@http.controller('/some/base')
export class MyController {
  @http.GET('status')
  async getStatus() {
    // ...
  }
}
```

Deepkit will generate a route with URL `/some/base/status`.  However, the generated API spec does not, instead producing `/some/basestatus`.

Before:
<img width="373" alt="image" src="https://user-images.githubusercontent.com/1029297/226143932-52c9e4f7-a005-445d-843b-e6b6a1dfa8d5.png">

After:
<img width="407" alt="image" src="https://user-images.githubusercontent.com/1029297/226143934-19233db9-c0ef-4ec9-b041-b7312760f596.png">
