### PR TITLE
add date support

### DIFF
--- a/packages/deepkit-openapi-core/src/TypeSchemaResolver.ts
+++ b/packages/deepkit-openapi-core/src/TypeSchemaResolver.ts
@@ -7,6 +7,7 @@ import {
 import { AnySchema, Schema } from "./types";
 
 import {
+  isDateType,
   reflect,
   ReflectionKind,
   stringifyType,
@@ -107,6 +108,12 @@ export class TypeSchemaResolver {
       this.t.kind !== ReflectionKind.class &&
       this.t.kind !== ReflectionKind.objectLiteral
     ) {
+      return;
+    }
+
+    // Dates will be serialized to string
+    if (isDateType(this.t)) {
+      this.result.type = "string";
       return;
     }
 


### PR DESCRIPTION
Dates output as empty objects in OpenAPI right now, but in reality, they're transformed into ISO 8601 strings when they're stringified.