### PR TITLE
fix Yarn workspaces issue, bump to 0.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,9 @@ jobs:
             cp README.md /home/circleci/project/packages/deepkit-openapi/
             cp README.md /home/circleci/project/packages/deepkit-openapi-core/
 
+            CORE_VERSION=$(node -p "require('./packages/deepkit-openapi-core/package.json').version")
+            sed -i "s/\"workspace:\\^\"/\"^$CORE_VERSION\"/" /home/circleci/project/packages/deepkit-openapi/package.json
+
             cd /home/circleci/project/packages/deepkit-openapi-core
             npm publish || true
             cd /home/circleci/project/packages/deepkit-openapi

--- a/packages/deepkit-openapi-core/package.json
+++ b/packages/deepkit-openapi-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepkit-openapi-core",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "",
   "main": "./dist/cjs/index.js",
   "types": "./dist/cjs/index.d.ts",

--- a/packages/deepkit-openapi/package.json
+++ b/packages/deepkit-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepkit-openapi",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "",
   "main": "./dist/cjs/index.js",
   "types": "./dist/cjs/index.d.ts",
@@ -10,7 +10,7 @@
     }
   },
   "dependencies": {
-    "deepkit-openapi-core": "workspace:*",
+    "deepkit-openapi-core": "workspace:^",
     "swagger-ui-dist": "^5.20.0",
     "yaml": "^2.7.0"
   },


### PR DESCRIPTION
Can't install latest (0.9.0) `deepkit-openapi` with Yarn (not sure about npm) due to the published version including `workspace:*` as the dependent version for `deepkit-openapi-core`.

This was caused by #12 switching to Yarn workspaces but not properly handling deployments (`yarn npm publish` automatically handles this but we're CI is not currently using that)